### PR TITLE
makeLoft accepts kwargs

### DIFF
--- a/freecad_stubs/Part-stubs/__init__.pyi
+++ b/freecad_stubs/Part-stubs/__init__.pyi
@@ -7824,7 +7824,7 @@ def makeSweepSurface(path: PartModule.Shape, profile: PartModule.Shape, toleranc
     """
 
 
-def makeLoft(pcObj, solid: bool = False, ruled: bool = False, closed: bool = False, maxDegree: int = 5, /) -> PartModule.Shape:
+def makeLoft(pcObj, /, solid: bool = False, ruled: bool = False, closed: bool = False, maxDegree: int = 5) -> PartModule.Shape:
     """
     makeLoft(list of wires,[solid=False,ruled=False,closed=False,maxDegree=5]) -- Create a loft shape.
     Possible exceptions: (Exception).


### PR DESCRIPTION
This is a followup to #35.

I looked at [the code you linked](https://github.com/FreeCAD/FreeCAD/blame/463c7f72a1643b916ebfe7fb378209a536c711a9/src/Mod/Part/App/AppPartPy.cpp#L1865) and it looks like kwargs are accepted.